### PR TITLE
Added a script to clean up old videos and playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
-<img align="left" width="65" height="65" src="/assets/logo.png">
+<img align="left" width="65" height="65" alt="Logo cartoon of birdbox with CCTV inside" src="/assets/logo.png">
 
 # birdbox-livestream
 
 This is a small collection of Python scripts designed for livestreaming a birdbox from a Raspberry Pi to YouTube!
 
-### **[Check out the channel on YouTube!](https://www.youtube.com/channel/UCikUXkTwFvyrHlajBRQwvuw)** (unfortunately no birds showed up 😢)
+### **[Check out the channel on YouTube!](https://www.youtube.com/channel/UCikUXkTwFvyrHlajBRQwvuw)
 
-[<img src="/assets/my-birdbox.png" alt="" width="500" />](https://www.youtube.com/channel/UCikUXkTwFvyrHlajBRQwvuw)
+** (unfortunately no birds have shown up yet 😢)
+
+[<img src="/assets/my-birdbox.png" alt="Photo of wooden birdbox on a red brick wall with a CCTV warning on the side" width="500" />](https://www.youtube.com/channel/UCikUXkTwFvyrHlajBRQwvuw)
 
 [![GitHub license](https://img.shields.io/github/license/cmenon12/birdbox-livestream?style=flat)](https://github.com/cmenon12/birdbox-livestream/blob/master/LICENSE)
-
 
 ## The Python Scripts
 
@@ -34,6 +35,12 @@ for regularly) it's downloaded in 144p, motion detection is run on it, and the r
 description. If any motion is detected, the timestamps are added to the description and emailed to the user.
 
 This script relies on `yt_livestream.py` for connecting to the YouTube API and sending error emails.
+
+#### [`yt_cleanup.py`](yt_cleanup.py)
+
+This script is used to clean up old videos and weekly playlists, either by deleting them or making them private. It can
+clean up a subset of them between two specified dates. Be careful not to exceed
+the [daily YouTube API quota](https://developers.google.com/youtube/v3/getting-started#quota) using this tool.
 
 #### [`reauth_token.py`](reauth_token.py)
 

--- a/google_services.py
+++ b/google_services.py
@@ -254,7 +254,7 @@ class YouTube(GoogleService):
         """Fetch all the playlists.
 
         :return: the playlists
-        :rtype: list[yt_types.YouTubePlaylist]
+        :rtype: List[yt_types.YouTubePlaylist]
         """
 
         LOGGER.debug("Fetching all the playlists...")

--- a/requirements-pi.txt
+++ b/requirements-pi.txt
@@ -5,6 +5,7 @@ google-auth-httplib2==0.2.0
 google-auth-oauthlib==1.2.0
 humanize==4.9.0
 pushbullet.py==0.12.0
+pick==2.2.0
 pytz==2021.3
 typing_extensions==4.9.0
 tzlocal==5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ html2text==2020.1.16
 humanize==4.9.0
 Jinja2==3.1.3
 opencv-python==4.8.1.78
+pick==2.2.0
 progress-bar==8
 pushbullet.py==0.12.0
 pytz==2021.3

--- a/yt_cleanup.py
+++ b/yt_cleanup.py
@@ -1,7 +1,9 @@
 import configparser
+import json
 import logging
 import sys
 from datetime import datetime
+from typing import List
 
 from pick import pick
 from pytz import timezone
@@ -12,6 +14,7 @@ __license__ = "gpl-3.0"
 
 import utilities
 from google_services import YouTube
+from yt_types import YouTubePlaylist
 
 # The name of the config file
 CONFIG_FILENAME = "config.ini"
@@ -23,6 +26,65 @@ TIMEZONE = timezone("Europe/London")
 LOG_FILENAME = f"birdbox-livestream-yt-livestream-{datetime.now(tz=TIMEZONE).strftime('%Y-%m-%d %H-%M-%S %Z')}.txt"
 
 
+def update_weekly_playlists(yt: YouTube, start_date: datetime = None, end_date: datetime = None,
+                            delete: bool = False, privacy: str = "private", ):
+    LOGGER.info("Updating playlists...")
+    LOGGER.info(locals())
+
+    playlists: List[YouTubePlaylist] = []
+    next_page_token = ""
+
+    while True:
+        response = yt.execute_request(yt.get_service().playlists().list(
+            part="id,snippet",
+            mine=True,
+            maxResults=50,
+            pageToken=next_page_token
+        ))
+
+        for playlist in response["items"]:
+            date = datetime.strptime(playlist["snippet"]["publishedAt"], "%Y-%m-%dT%H:%M:%SZ")
+            if (start_date and date < start_date) or (end_date and date > end_date):
+                continue
+            if ": w/c" in playlist["snippet"]["title"]:
+                playlists.append(playlist)
+        LOGGER.debug("Found %s new playlists.", len(response["items"]))
+
+        try:
+            next_page_token = response["nextPageToken"]
+        except KeyError:
+            break
+
+    LOGGER.debug("Found %s playlists in total.", len(playlists))
+
+    titles = [playlist["snippet"]["title"] for playlist in playlists]
+    print(
+        f"Are you sure you want to {'delete' if delete else privacy} all these playlists?\n{json.dumps(titles, indent=4)}")
+    answer = input("y/n: ")
+    LOGGER.info("User chose option %s.", answer)
+
+    if answer != "y":
+        LOGGER.info("User chose not to continue, exiting.")
+        sys.exit()
+
+    for playlist in playlists:
+
+        if delete:
+            r = yt.execute_request(yt.get_service().playlists().delete(
+                id=playlist["id"]
+            ))
+            LOGGER.debug("Deleted playlist %s %s.", playlist["id"], playlist["snippet"]["title"])
+        else:
+            body = {"id": playlist["id"], "status": {"privacyStatus": "private"}}
+            r = yt.execute_request(yt.get_service().playlist().update(
+                part="id,status",
+                body=body
+            ))
+            LOGGER.debug("Updated playlist %s %s.", playlist["id"], playlist["snippet"]["title"])
+
+    LOGGER.info("Updated the playlists successfully!")
+
+
 def main():
     # Get the config
     parser = utilities.load_config(CONFIG_FILENAME)
@@ -32,13 +94,19 @@ def main():
 
     title = "What do you want to do?"
     options = ["make weekly playlists private", "delete weekly playlists"]
-    option, index = pick(options, title)
+    option, _ = pick(options, title)
     LOGGER.info("User chose option %s.", option)
 
+    start_date = input("Enter the start date (YYYY-MM-DD): ")
+    start_date = datetime.strptime(start_date, "%Y-%m-%d") if start_date else None
+
+    end_date = input("Enter the end date (YYYY-MM-DD): ")
+    end_date = datetime.strptime(end_date, "%Y-%m-%d") if end_date else None
+
     if option == "make weekly playlists private":
-        update_playlists(yt, delete=False, privacy="private")
+        update_weekly_playlists(yt, start_date, end_date, delete=False, privacy="private")
     elif option == "delete weekly playlists":
-        update_playlists(yt, delete=True)
+        update_weekly_playlists(yt, start_date, end_date, delete=True, )
 
 
 if __name__ == "__main__":

--- a/yt_cleanup.py
+++ b/yt_cleanup.py
@@ -1,0 +1,54 @@
+import configparser
+import logging
+import sys
+from datetime import datetime
+
+from pick import pick
+from pytz import timezone
+
+__author__ = "Christopher Menon"
+__credits__ = "Christopher Menon"
+__license__ = "gpl-3.0"
+
+import utilities
+from google_services import YouTube
+
+# The name of the config file
+CONFIG_FILENAME = "config.ini"
+
+# The timezone to use throughout
+TIMEZONE = timezone("Europe/London")
+
+# The filename to use for the log file
+LOG_FILENAME = f"birdbox-livestream-yt-livestream-{datetime.now(tz=TIMEZONE).strftime('%Y-%m-%d %H-%M-%S %Z')}.txt"
+
+
+def main():
+    # Get the config
+    parser = utilities.load_config(CONFIG_FILENAME)
+    yt_config: configparser.SectionProxy = parser["YouTubeLivestream"]
+
+    yt = YouTube(yt_config)
+
+    title = "What do you want to do?"
+    options = ["make weekly playlists private", "delete weekly playlists"]
+    option, index = pick(options, title)
+    LOGGER.info("User chose option %s.", option)
+
+    if option == "make weekly playlists private":
+        update_playlists(yt, delete=False, privacy="private")
+    elif option == "delete weekly playlists":
+        update_playlists(yt, delete=True)
+
+
+if __name__ == "__main__":
+
+    # Prepare the log
+    LOGGER = utilities.prepare_logging(LOG_FILENAME)
+    LOGGER.addHandler(logging.StreamHandler(sys.stdout))
+
+    # Run it
+    main()
+
+else:
+    LOGGER = logging.getLogger(__name__)

--- a/yt_livestream.py
+++ b/yt_livestream.py
@@ -15,7 +15,7 @@ import time
 import traceback
 from datetime import datetime, timedelta
 from enum import Enum, auto
-from typing import Optional, Dict
+from typing import Optional, Dict, List
 
 import googleapiclient
 from pytz import timezone
@@ -370,19 +370,19 @@ class YouTubeLivestream(google_services.YouTube):
             **self.live_broadcasts,
             **self.finished_broadcasts}
 
-    def list_all_broadcasts(self, part: str, lifecycle_status: list[str] = None, broadcast_id: list[str] = None) -> \
-            list[
+    def list_all_broadcasts(self, part: str, lifecycle_status: List[str] = None, broadcast_id: List[str] = None) -> \
+            List[
                 yt_types.YouTubeLiveBroadcast]:
         """Fetch and return all the user's broadcasts.
 
         :param part: the comma-separated properties to fetch
         :type part: str
         :param lifecycle_status: the lifecycle statuses of the broadcasts to fetch
-        :type lifecycle_status: list[str]
+        :type lifecycle_status: List[str]
         :param broadcast_id: a list of IDs to fetch
-        :type broadcast_id: list[str]
+        :type broadcast_id: List[str]
         :return: all the broadcasts
-        :rtype: list[yt_types.YouTubeLiveBroadcast]
+        :rtype: List[yt_types.YouTubeLiveBroadcast]
         """
 
         LOGGER.debug("Fetching all the broadcasts...")
@@ -619,7 +619,7 @@ class YouTubeLivestream(google_services.YouTube):
         return broadcasts[0]["status"]
 
     def delete_broadcast(self, video_id: str, start_time: datetime,
-                         all_playlists: list[yt_types.YouTubePlaylist] = None):
+                         all_playlists: List[yt_types.YouTubePlaylist] = None):
         """Delete a broadcast and remove it from its playlist."""
 
         LOGGER.info("Deleting broadcast %s...", video_id)

--- a/yt_livestream.py
+++ b/yt_livestream.py
@@ -370,6 +370,50 @@ class YouTubeLivestream(google_services.YouTube):
             **self.live_broadcasts,
             **self.finished_broadcasts}
 
+    def list_all_broadcasts(self, part: str, lifecycle_status: list[str] = None, broadcast_id: list[str] = None) -> \
+            list[
+                yt_types.YouTubeLiveBroadcast]:
+        """Fetch and return all the user's broadcasts.
+
+        :param part: the comma-separated properties to fetch
+        :type part: str
+        :param lifecycle_status: the lifecycle statuses of the broadcasts to fetch
+        :type lifecycle_status: list[str]
+        :param broadcast_id: a list of IDs to fetch
+        :type broadcast_id: list[str]
+        :return: all the broadcasts
+        :rtype: list[yt_types.YouTubeLiveBroadcast]
+        """
+
+        LOGGER.debug("Fetching all the broadcasts...")
+        next_page_token = ""
+        all_broadcasts = []
+        while next_page_token is not None:
+            response: yt_types.YouTubeLiveBroadcastList = self.execute_request(
+                self.get_service().liveBroadcasts().list(
+                    part=part,
+                    mine=True,
+                    maxResults=50,
+                    pageToken=next_page_token))
+            LOGGER.debug("Response is: \n%s.",
+                         json.dumps(response, indent=4))
+            all_broadcasts.extend(response["items"])
+            next_page_token = response.get("nextPageToken")
+        LOGGER.debug("Broadcasts is: \n%s.",
+                     json.dumps(all_broadcasts, indent=4))
+
+        # Filter by lifecycle status
+        valid_broadcasts = []
+        for broadcast in all_broadcasts:
+            if lifecycle_status and broadcast["status"]["lifeCycleStatus"] not in lifecycle_status:
+                continue
+            if broadcast_id and broadcast["id"] not in broadcast_id:
+                continue
+            valid_broadcasts.append(broadcast)
+
+        LOGGER.debug("There are now %s valid broadcasts.", len(valid_broadcasts))
+        return valid_broadcasts
+
     def get_stream_status(self) -> yt_types.StreamStatus:
         """Fetch and return the status of the livestream.
 
@@ -569,13 +613,10 @@ class YouTubeLivestream(google_services.YouTube):
         :rtype: yt_types.BroadcastStatus
         """
 
-        broadcasts: yt_types.YouTubeLiveBroadcastList = self.execute_request(self.get_service().liveBroadcasts().list(
-            id=video_id,
-            part="status"
-        ))
+        broadcasts = self.list_all_broadcasts(part="status", broadcast_id=[video_id])
 
-        LOGGER.debug("Broadcast status of %s is: %s.", video_id, broadcasts["items"][0]["status"])
-        return broadcasts["items"][0]["status"]
+        LOGGER.debug("Broadcast status of %s is: %s.", video_id, broadcasts[0]["status"])
+        return broadcasts[0]["status"]
 
     def delete_broadcast(self, video_id: str, start_time: datetime,
                          all_playlists: list[yt_types.YouTubePlaylist] = None):
@@ -610,22 +651,7 @@ class YouTubeLivestream(google_services.YouTube):
 
         # Get all upcoming broadcasts
         LOGGER.debug("Fetching all the upcoming broadcasts...")
-        next_page_token = ""
-        all_broadcasts = []
-        while next_page_token is not None:
-            response: yt_types.YouTubeLiveBroadcastList = self.execute_request(
-                self.get_service().liveBroadcasts().list(
-                    part="id,snippet",
-                    broadcastStatus="upcoming",
-                    maxResults=50,
-                    pageToken=next_page_token))
-            LOGGER.debug(
-                "Response is: \n%s.", json.dumps(
-                    response, indent=4))
-            all_broadcasts.extend(response["items"])
-            next_page_token = response.get("nextPageToken")
-        LOGGER.debug("Broadcasts is: \n%s.",
-                     json.dumps(all_broadcasts, indent=4))
+        all_broadcasts = self.list_all_broadcasts(part="id,snippet", lifecycle_status=["created", "ready"])
 
         # Stop if there are no upcoming broadcasts
         if len(all_broadcasts) == 0:

--- a/yt_livestream.py
+++ b/yt_livestream.py
@@ -402,6 +402,9 @@ class YouTubeLivestream(google_services.YouTube):
         LOGGER.debug("Broadcasts is: \n%s.",
                      json.dumps(all_broadcasts, indent=4))
 
+        # Reverse order, so they're oldest first
+        all_broadcasts.reverse()
+
         # Filter by lifecycle status
         valid_broadcasts = []
         for broadcast in all_broadcasts:

--- a/yt_types.py
+++ b/yt_types.py
@@ -240,7 +240,7 @@ class YouTubeVideo(TypedDict, total=False):
     fileDetails: Dict[str, Union[str, int,
                                  List[Dict[str, Union[int, float, str]]]]]
     processingDetails: Dict[str, Union[str, Dict[str, int]]]
-    suggestions: Dict[str, Union[List[str], Dict[str, Union[str, List[str]]]]]
+    suggestions: Dict[str, Union[list[str], Dict[str, Union[str, List[str]]]]]
     liveStreamingDetails: Dict[str, Union[str, int]]
     localizations: Dict[str, Dict[str, str]]
 

--- a/yt_types.py
+++ b/yt_types.py
@@ -240,7 +240,7 @@ class YouTubeVideo(TypedDict, total=False):
     fileDetails: Dict[str, Union[str, int,
                                  List[Dict[str, Union[int, float, str]]]]]
     processingDetails: Dict[str, Union[str, Dict[str, int]]]
-    suggestions: Dict[str, Union[list[str], Dict[str, Union[str, List[str]]]]]
+    suggestions: Dict[str, Union[List[str], Dict[str, Union[str, List[str]]]]]
     liveStreamingDetails: Dict[str, Union[str, int]]
     localizations: Dict[str, Dict[str, str]]
 


### PR DESCRIPTION
Script with a basic CLI to clean up old videos with no motion and weekly playlists. Can either delete them or make them private. The user is given a list of items that will be affected and asked to confirm before proceeding.

Also created `YouTubeLivestream.list_all_broadcasts()` and `YouTubeLivestream.delete_broadcast()`, and switched to consistently using `typing.List` throughout.

Closes #56