### PR TITLE
Add comments to stream.sh, increase bitrate to 4240k, adjust flags

### DIFF
--- a/stream.sh
+++ b/stream.sh
@@ -4,7 +4,7 @@ read -e -p "What's the RTMP URL? " url
 
 while true
 do
-  raspivid -t 0 -w 1280 -h 720 -fps 25 -n -br 60 -co 10 -sh 70 -sa -100 -l -o - -a 1036 -a "%a %d %b %Y at %H:%M:%S %Z" -ae 18,0xff,0x808000 -ISO 600 -b 3500000 | ffmpeg -re -stream_loop -1 -i ./music/all-variable-120-mono.mp3 -i - -map 1:v -map 0:a -vcodec copy -acodec copy -ab 128k -g 50 -strict experimental -f flv -b:v 3500k -b:a 40k -maxrate 3540k -preset veryfast $url -report
+  raspivid -t 0 -w 1280 -h 720 -fps 25 -n -br 60 -co 10 -sh 70 -sa -100 -l -o - -a 1036 -a "%a %d %b %Y at %H:%M:%S %Z" -ae 18,0xff,0x808000 -ISO 600 -b 4000000 | ffmpeg -re -stream_loop -1 -i ./music/all-variable-120-mono.mp3 -i - -map 1:v -map 0:a -vcodec copy -acodec copy -ab 128k -g 50 -strict experimental -f flv -b:v 4000k -b:a 40k -maxrate 4040k -preset veryfast $url -report
 
   #   raspivid -t 0 -w 1280 -h 720 -fps 25 -n -br 60 -co 10 -sh 70 -sa -100 -l -o - -a 1036 -a "%a %d %b %Y at %H:%M %Z" -ae 18,0xff,0x808000 -ISO 600 -b 2800000 | ffmpeg -re -ar 44100 -ac 2 -acodec pcm_s16le -f s16le -ac 2 -i /dev/zero -f h264 -i - -vcodec copy -acodec aac -ab 128k -g 50 -strict experimental -f flv -b:v 2800k -b:a 1k -maxrate 2800k -bufsize 1400k -preset veryfast $url
 

--- a/stream.sh
+++ b/stream.sh
@@ -4,7 +4,41 @@ read -e -p "What's the RTMP URL? " url
 
 while true
 do
-  raspivid -t 0 -w 1280 -h 720 -fps 25 -n -br 60 -co 10 -sh 70 -sa -100 -l -o - -a 1036 -a "%a %d %b %Y at %H:%M:%S %Z" -ae 18,0xff,0x808000 -ISO 600 -b 4200000 | ffmpeg -re -stream_loop -1 -i ./music/all-variable-120-mono.mp3 -i - -map 1:v -map 0:a -vcodec copy -acodec copy -ab 128k -g 50 -strict experimental -f flv -b:v 4200k -b:a 40k -maxrate 4240k -preset veryfast $url -report
+  raspivid \
+    -t 0 \        # timeout in ms before stopping capture, 0 to disable
+    -w 1280 \     # width
+    -h 720 \      # height
+    -fps 25 \     # frames per second
+    -n \          # don't display a preview window
+    -br 60 \      # brightness, 0 to 100
+    -co 10 \      # contrast, -100 to 100
+    -sh 70 \      # sharpness, -100 to 100
+    -sa -100 \    # saturation, -100 to 100
+    -l \          # listen on a TCP socket
+    -o - \        # output to stdout
+    -a 1036 \     # set annotate flags or text
+    -a "%a %d %b %Y at %H:%M:%S %Z" \   # annotate string
+    -ae 18,0xff,0x808000 \              # set annotation text size, text colour, and background colour
+    -ISO 600 \          # set capture ISO
+    -b 4000000 |        # set bitrate in bits per second
+  ffmpeg -re \        # read input at the native framerate
+    -stream_loop -1 \   # loop indefinitely
+    -i ./music/all-variable-120-mono.mp3 \  # input file
+    -i - \              # input from stdin
+    -map 0:a \          # use the video from the second input
+    -map 1:v \          # use the audio from the first input
+    -vcodec copy \      # use the same video codec as the input
+    -acodec copy \      # use the same audio codec as the input
+    -ab 128k \
+    -g 50
+    -strict experimental  # should change to normal
+    -f flv              # set format
+    -b:v 4000k          # set the video bitrate
+    -b:a 40k            # set the audio bitrate
+    -maxrate 4040k      # set the maximum bitrate
+    -preset veryfast
+    $url
+    -report             # dump to a log file
 
   #   raspivid -t 0 -w 1280 -h 720 -fps 25 -n -br 60 -co 10 -sh 70 -sa -100 -l -o - -a 1036 -a "%a %d %b %Y at %H:%M %Z" -ae 18,0xff,0x808000 -ISO 600 -b 2800000 | ffmpeg -re -ar 44100 -ac 2 -acodec pcm_s16le -f s16le -ac 2 -i /dev/zero -f h264 -i - -vcodec copy -acodec aac -ab 128k -g 50 -strict experimental -f flv -b:v 2800k -b:a 1k -maxrate 2800k -bufsize 1400k -preset veryfast $url
 

--- a/stream.sh
+++ b/stream.sh
@@ -4,43 +4,43 @@ read -e -p "What's the RTMP URL? " url
 
 while true
 do
-  raspivid \
-    -t 0 \        # timeout in ms before stopping capture, 0 to disable
-    -w 1280 \     # width
-    -h 720 \      # height
-    -fps 25 \     # frames per second
-    -n \          # don't display a preview window
-    -br 60 \      # brightness, 0 to 100
-    -co 10 \      # contrast, -100 to 100
-    -sh 70 \      # sharpness, -100 to 100
-    -sa -100 \    # saturation, -100 to 100
-    -l \          # listen on a TCP socket
-    -o - \        # output to stdout
-    -a 1036 \     # set annotate flags or text
-    -a "%a %d %b %Y at %H:%M:%S %Z" \   # annotate string
-    -ae 18,0xff,0x808000 \              # set annotation text size, text colour, and background colour
-    -ISO 600 \          # set capture ISO
-    -b 4000000 |        # set bitrate in bits per second
-  ffmpeg -re \        # read input at the native framerate
-    -stream_loop -1 \   # loop indefinitely
-    -i ./music/all-variable-120-mono.mp3 \  # input file
-    -i - \              # input from stdin
-    -map 0:a \          # use the video from the second input
-    -map 1:v \          # use the audio from the first input
-    -vcodec copy \      # use the same video codec as the input
-    -acodec copy \      # use the same audio codec as the input
-    -ab 128k \
-    -g 50
-    -strict experimental  # should change to normal
-    -f flv              # set format
-    -b:v 4000k          # set the video bitrate
-    -b:a 40k            # set the audio bitrate
-    -maxrate 4040k      # set the maximum bitrate
-    -preset veryfast
-    $url
-    -report             # dump to a log file
+  # -t timeout in ms before stopping capture, 0 to disable
+  # -w width
+  # -h height
+  # -fps frames per second
+  # -n no preview window
+  # -br brightness, 0 to 100
+  # -co contrast, -100 to 100
+  # -sh sharpness, -100 to 100
+  # -sa saturation, -100 to 100
+  # -l listen on a TCP socket
+  # -o output to stdout
+  # -a set annotate flags or text
+  # -a annotate string
+  # -ae set annotate text size, text colour, and background colour
+  # -ISO set capture ISO
+  # -b set bitrate in bits per second
+  raspivid -t 0 -w 1280 -h 720 -fps 25 -n -br 60 -co 10 -sh 70 -sa -100 -l -o - -a 1036 -a "%a %d %b %Y at %H:%M:%S %Z" -ae 18,0xff,0x808000 -ISO 600 -b 4500000 |
 
-  #   raspivid -t 0 -w 1280 -h 720 -fps 25 -n -br 60 -co 10 -sh 70 -sa -100 -l -o - -a 1036 -a "%a %d %b %Y at %H:%M %Z" -ae 18,0xff,0x808000 -ISO 600 -b 2800000 | ffmpeg -re -ar 44100 -ac 2 -acodec pcm_s16le -f s16le -ac 2 -i /dev/zero -f h264 -i - -vcodec copy -acodec aac -ab 128k -g 50 -strict experimental -f flv -b:v 2800k -b:a 1k -maxrate 2800k -bufsize 1400k -preset veryfast $url
+  # -re read input at the native framerate
+  # -stream_loop loop input indefinitely
+  # -i input file
+  # -i input from stdin
+  # -map use the video from the second input
+  # -map use the audio from the first input
+  # -vcodec use the same video codec as the input
+  # -acodec use the same audio codec as the input
+  # -ab
+  # -g set the group of picture size
+  # -strict should change to normal
+  # -f set format
+  # -b set the video bitrate
+  # -b set the audio bitrate
+  # -maxrate set the maximum bitrate
+  # -preset
+  # the url variable
+  # -report dump to a log file
+  ffmpeg -re -stream_loop -1 -i ./music/all-variable-120-mono.mp3 -i - -map 1:v -map 0:a -vcodec copy -acodec copy -ab 128k -g 50 -strict experimental -f flv -b:v 4500k -b:a 40k -maxrate 4540k -preset veryfast $url -report
 
   sleep 30
 done

--- a/stream.sh
+++ b/stream.sh
@@ -30,7 +30,6 @@ do
   # -map use the audio from the first input
   # -vcodec use the same video codec as the input
   # -acodec use the same audio codec as the input
-  # -g set the group of picture size
   # -strict how strictly to conform to the codecs
   # -f set format
   # -b set the video bitrate

--- a/stream.sh
+++ b/stream.sh
@@ -4,7 +4,7 @@ read -e -p "What's the RTMP URL? " url
 
 while true
 do
-  raspivid -t 0 -w 1280 -h 720 -fps 25 -n -br 60 -co 10 -sh 70 -sa -100 -l -o - -a 1036 -a "%a %d %b %Y at %H:%M:%S %Z" -ae 18,0xff,0x808000 -ISO 600 -b 4000000 | ffmpeg -re -stream_loop -1 -i ./music/all-variable-120-mono.mp3 -i - -map 1:v -map 0:a -vcodec copy -acodec copy -ab 128k -g 50 -strict experimental -f flv -b:v 4000k -b:a 40k -maxrate 4040k -preset veryfast $url -report
+  raspivid -t 0 -w 1280 -h 720 -fps 25 -n -br 60 -co 10 -sh 70 -sa -100 -l -o - -a 1036 -a "%a %d %b %Y at %H:%M:%S %Z" -ae 18,0xff,0x808000 -ISO 600 -b 4500000 | ffmpeg -re -stream_loop -1 -i ./music/all-variable-120-mono.mp3 -i - -map 1:v -map 0:a -vcodec copy -acodec copy -ab 128k -g 50 -strict experimental -f flv -b:v 4500k -b:a 40k -maxrate 4540k -preset veryfast $url -report
 
   #   raspivid -t 0 -w 1280 -h 720 -fps 25 -n -br 60 -co 10 -sh 70 -sa -100 -l -o - -a 1036 -a "%a %d %b %Y at %H:%M %Z" -ae 18,0xff,0x808000 -ISO 600 -b 2800000 | ffmpeg -re -ar 44100 -ac 2 -acodec pcm_s16le -f s16le -ac 2 -i /dev/zero -f h264 -i - -vcodec copy -acodec aac -ab 128k -g 50 -strict experimental -f flv -b:v 2800k -b:a 1k -maxrate 2800k -bufsize 1400k -preset veryfast $url
 

--- a/stream.sh
+++ b/stream.sh
@@ -20,7 +20,7 @@ do
   # -ae set annotate text size, text colour, and background colour
   # -ISO set capture ISO
   # -b set bitrate in bits per second
-  raspivid -t 0 -w 1280 -h 720 -fps 25 -n -br 60 -co 10 -sh 70 -sa -100 -l -o - -a 1036 -a "%a %d %b %Y at %H:%M:%S %Z" -ae 18,0xff,0x808000 -ISO 600 -b 4500000 |
+  raspivid -t 0 -w 1280 -h 720 -fps 25 -n -br 60 -co 10 -sh 70 -sa -100 -l -o - -a 1036 -a "%a %d %b %Y at %H:%M:%S %Z" -ae 18,0xff,0x808000 -ISO 600 -b 4200000 |
 
   # -re read input at the native framerate
   # -stream_loop loop input indefinitely
@@ -30,17 +30,16 @@ do
   # -map use the audio from the first input
   # -vcodec use the same video codec as the input
   # -acodec use the same audio codec as the input
-  # -ab
   # -g set the group of picture size
-  # -strict should change to normal
+  # -strict how strictly to conform to the codecs
   # -f set format
   # -b set the video bitrate
   # -b set the audio bitrate
   # -maxrate set the maximum bitrate
-  # -preset
+  # -preset compression to encoding speed ration, faster=CPU keeps up better
   # the url variable
   # -report dump to a log file
-  ffmpeg -re -stream_loop -1 -i ./music/all-variable-120-mono.mp3 -i - -map 1:v -map 0:a -vcodec copy -acodec copy -ab 128k -g 50 -strict experimental -f flv -b:v 4500k -b:a 40k -maxrate 4540k -preset veryfast $url -report
+  ffmpeg -re -stream_loop -1 -i ./music/all-variable-120-mono.mp3 -i - -map 1:v -map 0:a -vcodec copy -acodec copy -strict normal -f flv -b:v 4200k -b:a 40k -maxrate 4240k -preset ultrafast $url -report
 
   sleep 30
 done

--- a/stream.sh
+++ b/stream.sh
@@ -4,7 +4,7 @@ read -e -p "What's the RTMP URL? " url
 
 while true
 do
-  raspivid -t 0 -w 1280 -h 720 -fps 25 -n -br 60 -co 10 -sh 70 -sa -100 -l -o - -a 1036 -a "%a %d %b %Y at %H:%M:%S %Z" -ae 18,0xff,0x808000 -ISO 600 -b 4500000 | ffmpeg -re -stream_loop -1 -i ./music/all-variable-120-mono.mp3 -i - -map 1:v -map 0:a -vcodec copy -acodec copy -ab 128k -g 50 -strict experimental -f flv -b:v 4500k -b:a 40k -maxrate 4540k -preset veryfast $url -report
+  raspivid -t 0 -w 1280 -h 720 -fps 25 -n -br 60 -co 10 -sh 70 -sa -100 -l -o - -a 1036 -a "%a %d %b %Y at %H:%M:%S %Z" -ae 18,0xff,0x808000 -ISO 600 -b 4200000 | ffmpeg -re -stream_loop -1 -i ./music/all-variable-120-mono.mp3 -i - -map 1:v -map 0:a -vcodec copy -acodec copy -ab 128k -g 50 -strict experimental -f flv -b:v 4200k -b:a 40k -maxrate 4240k -preset veryfast $url -report
 
   #   raspivid -t 0 -w 1280 -h 720 -fps 25 -n -br 60 -co 10 -sh 70 -sa -100 -l -o - -a 1036 -a "%a %d %b %Y at %H:%M %Z" -ae 18,0xff,0x808000 -ISO 600 -b 2800000 | ffmpeg -re -ar 44100 -ac 2 -acodec pcm_s16le -f s16le -ac 2 -i /dev/zero -f h264 -i - -vcodec copy -acodec aac -ab 128k -g 50 -strict experimental -f flv -b:v 2800k -b:a 1k -maxrate 2800k -bufsize 1400k -preset veryfast $url
 


### PR DESCRIPTION
- Played around with bitrates and increased from 3540k to 4240k. This is thanks to disabling VNC, removing Dataplicity, and disabling the GUI.
- Removed some flags that were not needed.
- Increase the `-preset` flag to `ultrafast` to help the CPU keep up.