### PR TITLE
#77 Suppress warning about unsupported caching

### DIFF
--- a/google_services.py
+++ b/google_services.py
@@ -145,7 +145,8 @@ class GoogleService:
                      self.token_file)
 
         # Create and return the authenticated service
-        service = build(self.service_name, self.service_version, credentials=credentials)
+        service = build(self.service_name, self.service_version, credentials=credentials,
+                        cache_discovery=False)
 
         assert os.path.exists(self.token_file)
 


### PR DESCRIPTION
Suppresses the warning to prevent it becoming a distraction. Although the default value was True the warning we were getting indicates that it wasn't doing any caching anyway.

See discussion at https://github.com/googleapis/google-api-python-client/issues/299

Resolves #77