### PR TITLE
Standardise datetime formatting

### DIFF
--- a/motion_detection.py
+++ b/motion_detection.py
@@ -27,7 +27,7 @@ import google_services
 import utilities
 import yt_livestream
 import yt_types
-from utilities import DatetimeFormat as DTFormat
+from utilities import DatetimeFormat as DTFmt
 
 __author__ = "Christopher Menon"
 __credits__ = "Christopher Menon"
@@ -40,7 +40,7 @@ CONFIG_FILENAME = "config.ini"
 TIMEZONE = timezone("Europe/London")
 
 # The filename to use for the log file
-LOG_FILENAME = f"birdbox-livestream-motion-detection-{datetime.now(tz=TIMEZONE).strftime(DTFormat.get_datetime_format(time_sep='.'))}.txt"
+LOG_FILENAME = f"birdbox-livestream-motion-detection-{datetime.now(tz=TIMEZONE).strftime(DTFmt.datetime_fmt(time_sep='.'))}.txt"
 
 # All the motion detection parameters
 MOTION_DETECTION_PARAMS = {

--- a/motion_detection.py
+++ b/motion_detection.py
@@ -27,6 +27,7 @@ import google_services
 import utilities
 import yt_livestream
 import yt_types
+from utilities import DatetimeFormat as dtf
 
 __author__ = "Christopher Menon"
 __credits__ = "Christopher Menon"
@@ -39,7 +40,7 @@ CONFIG_FILENAME = "config.ini"
 TIMEZONE = timezone("Europe/London")
 
 # The filename to use for the log file
-LOG_FILENAME = f"birdbox-livestream-motion-detection-{datetime.now(tz=TIMEZONE).strftime('%Y-%m-%d %H-%M-%S %Z')}.txt"
+LOG_FILENAME = f"birdbox-livestream-motion-detection-{datetime.now(tz=TIMEZONE).strftime(dtf.get_datetime_format(time_sep='.'))}.txt"
 
 # All the motion detection parameters
 MOTION_DETECTION_PARAMS = {

--- a/motion_detection.py
+++ b/motion_detection.py
@@ -27,7 +27,7 @@ import google_services
 import utilities
 import yt_livestream
 import yt_types
-from utilities import DatetimeFormat as dtf
+from utilities import DatetimeFormat as DTFormat
 
 __author__ = "Christopher Menon"
 __credits__ = "Christopher Menon"
@@ -40,7 +40,7 @@ CONFIG_FILENAME = "config.ini"
 TIMEZONE = timezone("Europe/London")
 
 # The filename to use for the log file
-LOG_FILENAME = f"birdbox-livestream-motion-detection-{datetime.now(tz=TIMEZONE).strftime(dtf.get_datetime_format(time_sep='.'))}.txt"
+LOG_FILENAME = f"birdbox-livestream-motion-detection-{datetime.now(tz=TIMEZONE).strftime(DTFormat.get_datetime_format(time_sep='.'))}.txt"
 
 # All the motion detection parameters
 MOTION_DETECTION_PARAMS = {

--- a/utilities.py
+++ b/utilities.py
@@ -100,8 +100,6 @@ class DatetimeFormat:
         return f"{DatetimeFormat.pretty_date_fmt(day, year)} at {DatetimeFormat.time_fmt(time_sep, seconds, tz)}"
 
 
-
-
 def prepare_logging(filename: str, level: int = logging.DEBUG) -> logging.Logger:
     """Prepares logging for the application.
 

--- a/utilities.py
+++ b/utilities.py
@@ -12,6 +12,83 @@ from email.mime.text import MIMEText
 from pathlib import Path
 
 
+class DatetimeFormat:
+    """A class to hold the datetime format strings."""
+
+    @staticmethod
+    def get_time_format(sep: str = ":", seconds: bool = True) -> str:
+        """Returns the time format string.
+
+        :param sep: the separator to use
+        :type sep: str
+        :param seconds: whether to include seconds
+        :type seconds: bool
+        :return: the time format string
+        :rtype: str
+        """
+
+        return f"%H{sep}%M{(f'{sep}%S' if seconds else '')}"
+
+    @staticmethod
+    def get_date_format(sep: str = "-") -> str:
+        """Returns the date format string.
+
+        :param sep: the separator to use
+        :type sep: str
+        :return: the date format string
+        :rtype: str
+        """
+
+        return f"%Y{sep}%m{sep}%d"
+
+    @staticmethod
+    def get_datetime_format(sep: str = " ", date_sep: str = "-", time_sep: str = ":") -> str:
+        """Returns the datetime format string.
+
+        :param sep: the separator to use
+        :type sep: str
+        :param date_sep: the date separator to use
+        :type date_sep: str
+        :param time_sep: the time separator to use
+        :type time_sep: str
+        :return: the datetime format string
+        :rtype: str
+        """
+
+        return f"{DatetimeFormat.get_date_format(date_sep)}{sep}{DatetimeFormat.get_time_format(time_sep)}"
+
+    @staticmethod
+    def get_pretty_date_format(day: bool = True) -> str:
+        """Returns the pretty date format string.
+
+        :param day: whether to include the day
+        :type day: bool
+        :return: the pretty date format string
+        :rtype: str
+        """
+
+        return f"{'%a ' if day else ''}%d %b %Y"
+
+    @staticmethod
+    def get_pretty_datetime_format(day: bool = True, time_sep: str = ":",
+                                   seconds: bool = True) -> str:
+        """Returns the pretty datetime format string.
+
+        :param day: whether to include the day
+        :type day: bool
+        :param time_sep: the time separator to use
+        :type time_sep: str
+        :param seconds: whether to include seconds
+        :type seconds: bool
+        :return: the pretty datetime format string
+        :rtype: str
+        """
+
+        return f"{DatetimeFormat.get_pretty_date_format(day)} at {DatetimeFormat.get_time_format(time_sep, seconds)}"
+
+
+
+
 def prepare_logging(filename: str, level: int = logging.DEBUG) -> logging.Logger:
     """Prepares logging for the application.
 

--- a/utilities.py
+++ b/utilities.py
@@ -16,7 +16,7 @@ class DatetimeFormat:
     """A class to hold the datetime format strings."""
 
     @staticmethod
-    def get_time_format(sep: str = ":", seconds: bool = True, tz: bool = False) -> str:
+    def time_fmt(sep: str = ":", seconds: bool = True, tz: bool = False) -> str:
         """Returns the time format string.
 
         :param sep: the separator to use
@@ -32,7 +32,7 @@ class DatetimeFormat:
         return f"%H{sep}%M{f'{sep}%S' if seconds else ''}{' %Z' if tz else ''}"
 
     @staticmethod
-    def get_date_format(sep: str = "-") -> str:
+    def date_fmt(sep: str = "-") -> str:
         """Returns the date format string.
 
         :param sep: the separator to use
@@ -44,8 +44,8 @@ class DatetimeFormat:
         return f"%Y{sep}%m{sep}%d"
 
     @staticmethod
-    def get_datetime_format(sep: str = " ", date_sep: str = "-", time_sep: str = ":",
-                            seconds: bool = True, tz: bool = False) -> str:
+    def datetime_fmt(sep: str = " ", date_sep: str = "-", time_sep: str = ":",
+                     seconds: bool = True, tz: bool = False) -> str:
         """Returns the datetime format string.
 
         :param sep: the separator to use
@@ -62,10 +62,10 @@ class DatetimeFormat:
         :rtype: str
         """
 
-        return f"{DatetimeFormat.get_date_format(date_sep)}{sep}{DatetimeFormat.get_time_format(time_sep, seconds, tz)}"
+        return f"{DatetimeFormat.date_fmt(date_sep)}{sep}{DatetimeFormat.time_fmt(time_sep, seconds, tz)}"
 
     @staticmethod
-    def get_pretty_date_format(day: bool = True, year: bool = True) -> str:
+    def pretty_date_fmt(day: bool = True, year: bool = True) -> str:
         """Returns the pretty date format string.
 
         :param day: whether to include the day
@@ -79,8 +79,8 @@ class DatetimeFormat:
         return f"{'%a ' if day else ''}%d %b{' %Y' if year else ''}"
 
     @staticmethod
-    def get_pretty_datetime_format(day: bool = True, year: bool = True, time_sep: str = ":",
-                                   seconds: bool = True, tz: bool = False) -> str:
+    def pretty_datetime_fmt(day: bool = True, year: bool = True, time_sep: str = ":",
+                            seconds: bool = True, tz: bool = False) -> str:
         """Returns the pretty datetime format string.
 
         :param day: whether to include the day
@@ -97,7 +97,7 @@ class DatetimeFormat:
         :rtype: str
         """
 
-        return f"{DatetimeFormat.get_pretty_date_format(day, year)} at {DatetimeFormat.get_time_format(time_sep, seconds, tz)}"
+        return f"{DatetimeFormat.pretty_date_fmt(day, year)} at {DatetimeFormat.time_fmt(time_sep, seconds, tz)}"
 
 
 

--- a/utilities.py
+++ b/utilities.py
@@ -42,7 +42,8 @@ class DatetimeFormat:
         return f"%Y{sep}%m{sep}%d"
 
     @staticmethod
-    def get_datetime_format(sep: str = " ", date_sep: str = "-", time_sep: str = ":") -> str:
+    def get_datetime_format(sep: str = " ", date_sep: str = "-", time_sep: str = ":",
+                            seconds: bool = True) -> str:
         """Returns the datetime format string.
 
         :param sep: the separator to use
@@ -51,11 +52,13 @@ class DatetimeFormat:
         :type date_sep: str
         :param time_sep: the time separator to use
         :type time_sep: str
+        :param seconds: whether to include seconds
+        :type seconds: bool
         :return: the datetime format string
         :rtype: str
         """
 
-        return f"{DatetimeFormat.get_date_format(date_sep)}{sep}{DatetimeFormat.get_time_format(time_sep)}"
+        return f"{DatetimeFormat.get_date_format(date_sep)}{sep}{DatetimeFormat.get_time_format(time_sep, seconds)}"
 
     @staticmethod
     def get_pretty_date_format(day: bool = True) -> str:

--- a/utilities.py
+++ b/utilities.py
@@ -65,24 +65,28 @@ class DatetimeFormat:
         return f"{DatetimeFormat.get_date_format(date_sep)}{sep}{DatetimeFormat.get_time_format(time_sep, seconds, tz)}"
 
     @staticmethod
-    def get_pretty_date_format(day: bool = True) -> str:
+    def get_pretty_date_format(day: bool = True, year: bool = True) -> str:
         """Returns the pretty date format string.
 
         :param day: whether to include the day
         :type day: bool
+        :param year: whether to include the year
+        :type year: bool
         :return: the pretty date format string
         :rtype: str
         """
 
-        return f"{'%a ' if day else ''}%d %b %Y"
+        return f"{'%a ' if day else ''}%d %b{' %Y' if year else ''}"
 
     @staticmethod
-    def get_pretty_datetime_format(day: bool = True, time_sep: str = ":",
+    def get_pretty_datetime_format(day: bool = True, year: bool = True, time_sep: str = ":",
                                    seconds: bool = True, tz: bool = False) -> str:
         """Returns the pretty datetime format string.
 
         :param day: whether to include the day
         :type day: bool
+        :param year: whether to include the year
+        :type year: bool
         :param time_sep: the time separator to use
         :type time_sep: str
         :param seconds: whether to include seconds
@@ -93,7 +97,7 @@ class DatetimeFormat:
         :rtype: str
         """
 
-        return f"{DatetimeFormat.get_pretty_date_format(day)} at {DatetimeFormat.get_time_format(time_sep, seconds, tz)}"
+        return f"{DatetimeFormat.get_pretty_date_format(day, year)} at {DatetimeFormat.get_time_format(time_sep, seconds, tz)}"
 
 
 

--- a/utilities.py
+++ b/utilities.py
@@ -16,18 +16,20 @@ class DatetimeFormat:
     """A class to hold the datetime format strings."""
 
     @staticmethod
-    def get_time_format(sep: str = ":", seconds: bool = True) -> str:
+    def get_time_format(sep: str = ":", seconds: bool = True, tz: bool = False) -> str:
         """Returns the time format string.
 
         :param sep: the separator to use
         :type sep: str
         :param seconds: whether to include seconds
         :type seconds: bool
+        :param tz: whether to include the timezone
+        :type tz: bool
         :return: the time format string
         :rtype: str
         """
 
-        return f"%H{sep}%M{(f'{sep}%S' if seconds else '')}"
+        return f"%H{sep}%M{f'{sep}%S' if seconds else ''}{' %Z' if tz else ''}"
 
     @staticmethod
     def get_date_format(sep: str = "-") -> str:
@@ -43,7 +45,7 @@ class DatetimeFormat:
 
     @staticmethod
     def get_datetime_format(sep: str = " ", date_sep: str = "-", time_sep: str = ":",
-                            seconds: bool = True) -> str:
+                            seconds: bool = True, tz: bool = False) -> str:
         """Returns the datetime format string.
 
         :param sep: the separator to use
@@ -54,11 +56,13 @@ class DatetimeFormat:
         :type time_sep: str
         :param seconds: whether to include seconds
         :type seconds: bool
+        :param tz: whether to include the timezone
+        :type tz: bool
         :return: the datetime format string
         :rtype: str
         """
 
-        return f"{DatetimeFormat.get_date_format(date_sep)}{sep}{DatetimeFormat.get_time_format(time_sep, seconds)}"
+        return f"{DatetimeFormat.get_date_format(date_sep)}{sep}{DatetimeFormat.get_time_format(time_sep, seconds, tz)}"
 
     @staticmethod
     def get_pretty_date_format(day: bool = True) -> str:
@@ -74,7 +78,7 @@ class DatetimeFormat:
 
     @staticmethod
     def get_pretty_datetime_format(day: bool = True, time_sep: str = ":",
-                                   seconds: bool = True) -> str:
+                                   seconds: bool = True, tz: bool = False) -> str:
         """Returns the pretty datetime format string.
 
         :param day: whether to include the day
@@ -83,11 +87,13 @@ class DatetimeFormat:
         :type time_sep: str
         :param seconds: whether to include seconds
         :type seconds: bool
+        :param tz: whether to include the timezone
+        :type tz: bool
         :return: the pretty datetime format string
         :rtype: str
         """
 
-        return f"{DatetimeFormat.get_pretty_date_format(day)} at {DatetimeFormat.get_time_format(time_sep, seconds)}"
+        return f"{DatetimeFormat.get_pretty_date_format(day)} at {DatetimeFormat.get_time_format(time_sep, seconds, tz)}"
 
 
 

--- a/yt_cleanup.py
+++ b/yt_cleanup.py
@@ -12,6 +12,7 @@ __author__ = "Christopher Menon"
 __credits__ = "Christopher Menon"
 __license__ = "gpl-3.0"
 
+from utilities import DatetimeFormat as DTFormat
 import utilities
 from yt_livestream import YouTubeLivestream
 from yt_types import YouTubePlaylist, YouTubeLiveBroadcast
@@ -23,7 +24,7 @@ CONFIG_FILENAME = "config.ini"
 TIMEZONE = timezone("Europe/London")
 
 # The filename to use for the log file
-LOG_FILENAME = f"birdbox-livestream-yt-cleanup-{datetime.now(tz=TIMEZONE).strftime('%Y-%m-%d %H-%M-%S %Z')}.txt"
+LOG_FILENAME = f"birdbox-livestream-yt-cleanup-{datetime.now(tz=TIMEZONE).strftime(DTFormat.get_datetime_format(time_sep='.'))}.txt"
 
 
 def ask_yes_or_no():
@@ -118,7 +119,8 @@ def update_weekly_playlists(yt: YouTubeLivestream, privacy: str,
     playlists: List[YouTubePlaylist] = []
     for playlist in all_playlists:
         if ": w/c" in playlist["snippet"]["title"]:
-            date = datetime.strptime(playlist["snippet"]["title"][-11:], "%d %b %Y")
+            date = datetime.strptime(playlist["snippet"]["title"][-11:],
+                                     DTFormat.get_pretty_date_format(day=False))
             if (start_date and date < start_date) or (end_date and date > end_date):
                 continue
             if playlist["status"]["privacyStatus"] == privacy:

--- a/yt_cleanup.py
+++ b/yt_cleanup.py
@@ -60,7 +60,7 @@ def update_no_motion_videos(yt: YouTubeLivestream, privacy: str,
     all_videos = yt.list_all_broadcasts(part="id,snippet,status", broadcast_status="completed")
     for video in all_videos:
         if "(no motion)" in video["snippet"]["title"]:
-            date = datetime.fromisoformat(video["snippet"]["scheduledStartTime"])
+            date = yt.parse_scheduled_time(video["snippet"]["scheduledStartTime"])
             if (start_date and date < start_date) or (end_date and date > end_date):
                 continue
             if video["status"]["privacyStatus"] == privacy:
@@ -80,7 +80,7 @@ def update_no_motion_videos(yt: YouTubeLivestream, privacy: str,
     for video in videos:
 
         if privacy == "delete":
-            start_time = datetime.fromisoformat(video["snippet"]["scheduledStartTime"])
+            start_time = yt.parse_scheduled_time(video["snippet"]["scheduledStartTime"])
             yt.delete_broadcast(video["id"], start_time, all_playlists)
             yt.execute_request(yt.get_service().videos().delete(
                 id=video["id"]

--- a/yt_cleanup.py
+++ b/yt_cleanup.py
@@ -12,7 +12,7 @@ __author__ = "Christopher Menon"
 __credits__ = "Christopher Menon"
 __license__ = "gpl-3.0"
 
-from utilities import DatetimeFormat as DTFormat
+from utilities import DatetimeFormat as DTFmt
 import utilities
 from yt_livestream import YouTubeLivestream
 from yt_types import YouTubePlaylist, YouTubeLiveBroadcast
@@ -24,7 +24,7 @@ CONFIG_FILENAME = "config.ini"
 TIMEZONE = timezone("Europe/London")
 
 # The filename to use for the log file
-LOG_FILENAME = f"birdbox-livestream-yt-cleanup-{datetime.now(tz=TIMEZONE).strftime(DTFormat.get_datetime_format(time_sep='.'))}.txt"
+LOG_FILENAME = f"birdbox-livestream-yt-cleanup-{datetime.now(tz=TIMEZONE).strftime(DTFmt.datetime_fmt(time_sep='.'))}.txt"
 
 
 def ask_yes_or_no():
@@ -120,7 +120,7 @@ def update_weekly_playlists(yt: YouTubeLivestream, privacy: str,
     for playlist in all_playlists:
         if ": w/c" in playlist["snippet"]["title"]:
             date = datetime.strptime(playlist["snippet"]["title"][-11:],
-                                     DTFormat.get_pretty_date_format(day=False))
+                                     DTFmt.pretty_date_fmt(day=False))
             if (start_date and date < start_date) or (end_date and date > end_date):
                 continue
             if playlist["status"]["privacyStatus"] == privacy:

--- a/yt_cleanup.py
+++ b/yt_cleanup.py
@@ -60,7 +60,7 @@ def update_no_motion_videos(yt: YouTubeLivestream, privacy: str,
     all_videos = yt.list_all_broadcasts(part="id,snippet,status", broadcast_status="completed")
     for video in all_videos:
         if "(no motion)" in video["snippet"]["title"]:
-            date = datetime.strptime(video["snippet"]["scheduledStartTime"], "%Y-%m-%dT%H:%M:%SZ")
+            date = datetime.fromisoformat(video["snippet"]["scheduledStartTime"])
             if (start_date and date < start_date) or (end_date and date > end_date):
                 continue
             if video["status"]["privacyStatus"] == privacy:
@@ -80,7 +80,7 @@ def update_no_motion_videos(yt: YouTubeLivestream, privacy: str,
     for video in videos:
 
         if privacy == "delete":
-            start_time = datetime.strptime(video["snippet"]["scheduledStartTime"], "%Y-%m-%dT%H:%M:%SZ")
+            start_time = datetime.fromisoformat(video["snippet"]["scheduledStartTime"])
             yt.delete_broadcast(video["id"], start_time, all_playlists)
             yt.execute_request(yt.get_service().videos().delete(
                 id=video["id"]
@@ -171,10 +171,10 @@ def main():
     LOGGER.info("User chose option %s.", option)
 
     start_date = input("Enter the start date (YYYY-MM-DD): ")
-    start_date = datetime.strptime(start_date, "%Y-%m-%d") if start_date else None
+    start_date = datetime.strptime(start_date, DTFmt.date_fmt()) if start_date else None
 
     end_date = input("Enter the end date (YYYY-MM-DD): ")
-    end_date = datetime.strptime(end_date, "%Y-%m-%d") if end_date else None
+    end_date = datetime.strptime(end_date, DTFmt.date_fmt()) if end_date else None
 
     if option == "make weekly playlists private":
         update_weekly_playlists(yt, "private", start_date, end_date)

--- a/yt_livestream.py
+++ b/yt_livestream.py
@@ -23,7 +23,7 @@ from pytz import timezone
 import google_services
 import utilities
 import yt_types
-from utilities import DatetimeFormat as DTFormat
+from utilities import DatetimeFormat as DTFmt
 
 __author__ = "Christopher Menon"
 __credits__ = "Christopher Menon"
@@ -39,7 +39,7 @@ TIMEZONE = timezone("Europe/London")
 MAX_SCHEDULED_BROADCASTS = 2
 
 # The filename to use for the log file
-LOG_FILENAME = f"birdbox-livestream-yt-livestream-{datetime.now(tz=TIMEZONE).strftime(DTFormat.get_datetime_format(time_sep='.'))}.txt"
+LOG_FILENAME = f"birdbox-livestream-yt-livestream-{datetime.now(tz=TIMEZONE).strftime(DTFmt.datetime_fmt(time_sep='.'))}.txt"
 
 
 class BroadcastTypes(Enum):
@@ -99,7 +99,7 @@ class YouTubeLivestream(google_services.YouTube):
                     "contentDetails": {
                         "isReusable": True},
                     "snippet": {
-                        "title": f"Birdbox Livestream at {datetime.now(tz=TIMEZONE).strftime(DTFormat.get_datetime_format(tz=True))}"}}))
+                        "title": f"Birdbox Livestream at {datetime.now(tz=TIMEZONE).strftime(DTFmt.datetime_fmt(tz=True))}"}}))
         LOGGER.debug("Stream is: \n%s.", json.dumps(stream, indent=4))
 
         # Save and return it
@@ -145,14 +145,14 @@ class YouTubeLivestream(google_services.YouTube):
         if start_time in self.get_broadcasts().keys():
             LOGGER.debug(
                 "Returning existing broadcast at %s.",
-                start_time.strftime(DTFormat.get_datetime_format(tz=True)))
+                start_time.strftime(DTFmt.datetime_fmt(tz=True)))
             LOGGER.info("Broadcast scheduled successfully!\n")
             return self.get_broadcasts()[start_time]
 
         # Round the end time to the nearest 6 hours
         end_time = start_time.astimezone(TIMEZONE) + timedelta(minutes=360)
         LOGGER.debug("End time with no rounding is %s.",
-                     end_time.strftime(DTFormat.get_datetime_format(tz=True)))
+                     end_time.strftime(DTFmt.datetime_fmt(tz=True)))
 
         # If it's going to be tomorrow at midnight
         if round(end_time.hour / 6) * 6 >= 24:
@@ -166,11 +166,11 @@ class YouTubeLivestream(google_services.YouTube):
                                         hour=round(end_time.hour / 6) * 6)
         LOGGER.debug(
             "End time to the nearest hour is %s.",
-            end_time.strftime(DTFormat.get_datetime_format(tz=True)))
+            end_time.strftime(DTFmt.datetime_fmt(tz=True)))
 
         # Create a description
-        description = f"A livestream of the birdbox starting on {start_time.strftime(DTFormat.get_pretty_datetime_format(time_sep='.', seconds=False))}" \
-                      f" and ending at {end_time.strftime(DTFormat.get_time_format(sep='.', seconds=False))} ({str(TIMEZONE.zone)} timezone). "
+        description = f"A livestream of the birdbox starting on {start_time.strftime(DTFmt.pretty_datetime_fmt(time_sep='.', seconds=False))}" \
+                      f" and ending at {end_time.strftime(DTFmt.time_fmt(sep='.', seconds=False))} ({str(TIMEZONE.zone)} timezone). "
 
         # Schedule a new broadcast
         LOGGER.debug("Scheduling a new broadcast...")
@@ -190,7 +190,7 @@ class YouTubeLivestream(google_services.YouTube):
                     "snippet": {
                         "scheduledStartTime": start_time.isoformat(),
                         "scheduledEndTime": end_time.isoformat(),
-                        "title": f"Birdbox on {start_time.strftime(DTFormat.get_pretty_datetime_format(seconds=False))}",
+                        "title": f"Birdbox on {start_time.strftime(DTFmt.pretty_datetime_fmt(seconds=False))}",
                         "description": description},
                     "status": {
                         "privacyStatus": self.config["privacy_status"],
@@ -204,7 +204,7 @@ class YouTubeLivestream(google_services.YouTube):
         # Save and return it
         self.scheduled_broadcasts[start_time] = broadcast
         print(
-            f"Scheduled a broadcast at {start_time.strftime(DTFormat.get_datetime_format(tz=True))} till {end_time.strftime(DTFormat.get_datetime_format(tz=True))}")
+            f"Scheduled a broadcast at {start_time.strftime(DTFmt.datetime_fmt(tz=True))} till {end_time.strftime(DTFmt.datetime_fmt(tz=True))}")
         LOGGER.info("Broadcast scheduled successfully!\n")
         return broadcast
 
@@ -226,7 +226,7 @@ class YouTubeLivestream(google_services.YouTube):
         # Check that this broadcast exists.
         if start_time not in self.scheduled_broadcasts:
             raise ValueError(
-                f"The broadcast at {start_time.strftime(DTFormat.get_datetime_format(tz=True))} is not scheduled!")
+                f"The broadcast at {start_time.strftime(DTFmt.datetime_fmt(tz=True))} is not scheduled!")
 
         # Bind the broadcast to the stream
         LOGGER.debug("Binding the broadcast to the stream...")
@@ -299,7 +299,7 @@ class YouTubeLivestream(google_services.YouTube):
 
         # Return it
         print(
-            f"Started a broadcast at {start_time.strftime(DTFormat.get_datetime_format(tz=True))}")
+            f"Started a broadcast at {start_time.strftime(DTFmt.datetime_fmt(tz=True))}")
         LOGGER.info("Broadcast started successfully!\n")
         return broadcast
 
@@ -321,7 +321,7 @@ class YouTubeLivestream(google_services.YouTube):
         # Check that this broadcast exists
         if start_time not in self.live_broadcasts:
             raise ValueError(
-                f"The broadcast at {start_time.strftime(DTFormat.get_datetime_format(tz=True))} is not live!")
+                f"The broadcast at {start_time.strftime(DTFmt.datetime_fmt(tz=True))} is not live!")
 
         # Change its status to complete
         LOGGER.debug("Transitioning the broadcastStatus to complete...")
@@ -349,7 +349,7 @@ class YouTubeLivestream(google_services.YouTube):
         # Save and return the updated resource
         self.live_broadcasts.pop(start_time)
         print(
-            f"Ended a broadcast that started at {start_time.strftime(DTFormat.get_datetime_format(tz=True))}")
+            f"Ended a broadcast that started at {start_time.strftime(DTFmt.datetime_fmt(tz=True))}")
         LOGGER.info("Broadcast ended successfully!\n")
         return self.finished_broadcasts[start_time]
 
@@ -536,9 +536,9 @@ class YouTubeLivestream(google_services.YouTube):
             if "starting on" in description:
                 old_start_time = description[40:64]
                 new_description = description.replace(old_start_time, start_time.strftime(
-                    DTFormat.get_pretty_datetime_format(time_sep='.', seconds=False)))
+                    DTFmt.pretty_datetime_fmt(time_sep='.', seconds=False)))
                 LOGGER.debug("New description is: %s.", new_description)
-                new_title = f"Birdbox on {start_time.strftime(DTFormat.get_pretty_datetime_format(seconds=False))}"
+                new_title = f"Birdbox on {start_time.strftime(DTFmt.pretty_datetime_fmt(seconds=False))}"
                 self.update_video_metadata(video_id, title=new_title, description=new_description)
 
             # If asked then raise exception
@@ -551,8 +551,8 @@ class YouTubeLivestream(google_services.YouTube):
                 old_end_time = description[79:84]
                 new_description = description.replace(old_end_time,
                                                       end_time.strftime(
-                                                          DTFormat.get_time_format(sep='.',
-                                                                                   seconds=False)))
+                                                          DTFmt.time_fmt(sep='.',
+                                                                         seconds=False)))
                 LOGGER.debug("New description is: %s.", new_description)
                 self.update_video_metadata(video_id, description=new_description)
 
@@ -582,7 +582,7 @@ class YouTubeLivestream(google_services.YouTube):
                 start_time -
                 timedelta(
                     days=start_time.weekday())).strftime(
-            f"W%W: w/c {DTFormat.get_pretty_date_format(day=False)}")
+            f"W%W: w/c {DTFmt.pretty_date_fmt(day=False)}")
 
         # Only get the playlist for this week if we don't already have it
         if self.week_playlist is None or self.week_playlist["snippet"]["title"] != playlist_title:
@@ -599,7 +599,7 @@ class YouTubeLivestream(google_services.YouTube):
             else:
                 # Create a new playlist
                 LOGGER.debug("Creating a new playlist...")
-                description = f"This playlist has videos of the birdbox from {(start_time - timedelta(days=start_time.weekday())).strftime(DTFormat.get_pretty_date_format(year=False))} to {(start_time - timedelta(days=start_time.weekday() - 6)).strftime(DTFormat.get_pretty_date_format(year=False))}. "
+                description = f"This playlist has videos of the birdbox from {(start_time - timedelta(days=start_time.weekday())).strftime(DTFmt.pretty_date_fmt(year=False))} to {(start_time - timedelta(days=start_time.weekday() - 6)).strftime(DTFmt.pretty_date_fmt(year=False))}. "
                 self.week_playlist: yt_types.YouTubePlaylist = self.execute_request(
                     self.get_service().playlists().insert(
                         part="id,snippet,status", body={
@@ -638,7 +638,7 @@ class YouTubeLivestream(google_services.YouTube):
         # Calculate the playlist title
         playlist_title = (start_time - timedelta(
             days=start_time.weekday())).strftime(
-            f"W%W: w/c {DTFormat.get_pretty_date_format(day=False)}")
+            f"W%W: w/c {DTFmt.pretty_date_fmt(day=False)}")
 
         if all_playlists is None:
             all_playlists = self.list_all_playlists()

--- a/yt_livestream.py
+++ b/yt_livestream.py
@@ -678,7 +678,7 @@ class YouTubeLivestream(google_services.YouTube):
             if not broadcast["snippet"].get("scheduledStartTime"):
                 LOGGER.debug("Broadcast with ID %s has no scheduled start time, skipping.", broadcast["id"])
                 continue
-            start_time = datetime.strptime(broadcast["snippet"]["scheduledStartTime"], "%Y-%m-%dT%H:%M:%SZ")
+            start_time = datetime.fromisoformat(broadcast["snippet"]["scheduledStartTime"])
 
             self.delete_broadcast(broadcast["id"], start_time, all_playlists)
 

--- a/yt_types.py
+++ b/yt_types.py
@@ -1,10 +1,4 @@
-import sys
-from typing import List, Dict, Union
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict, Literal  # pylint: disable=no-name-in-module
-else:
-    from typing_extensions import TypedDict, Literal
+from typing import List, Dict, Union, TypedDict, Literal
 
 
 class Thumbnail(TypedDict, total=False):


### PR DESCRIPTION
- Create the DatetimeFormat class to generate datetime formats, and use this instead of repeating lots of format strings.
- Create `YouTubeLivestream.parse_scheduled_time()` to correctly parse the scheduled start and end times of broadcasts into a datetime object.
- Simplify imports in yt_types.py

Currently live in the birdbox, will wait to merge until it has run for a while successfully. Closes #74.