### PR TITLE
Wait before sending motion email

### DIFF
--- a/motion_detection.py
+++ b/motion_detection.py
@@ -289,6 +289,7 @@ def process_video(video_id: str, yt: google_services.YouTube,
             yt.get_service(), video_id, motion)
         if len(motion) > 0:
             # Wait before sending the email, as YouTube does not show the updated metadata straight away
+            print("Motion detected! Waiting 60 seconds before sending the email...")
             time.sleep(60)
             send_motion_email(email_config, video_id, motion, yt_config["motion_playlist_id"])
             yt.add_to_playlist(video_id, yt_config["motion_playlist_id"])

--- a/motion_detection.py
+++ b/motion_detection.py
@@ -288,6 +288,8 @@ def process_video(video_id: str, yt: google_services.YouTube,
         update_motion_status(
             yt.get_service(), video_id, motion)
         if len(motion) > 0:
+            # Wait before sending the email, as YouTube does not show the updated metadata straight away
+            time.sleep(60)
             send_motion_email(email_config, video_id, motion, yt_config["motion_playlist_id"])
             yt.add_to_playlist(video_id, yt_config["motion_playlist_id"])
         else:

--- a/motion_detection.py
+++ b/motion_detection.py
@@ -288,11 +288,11 @@ def process_video(video_id: str, yt: google_services.YouTube,
         update_motion_status(
             yt.get_service(), video_id, motion)
         if len(motion) > 0:
+            yt.add_to_playlist(video_id, yt_config["motion_playlist_id"])
             # Wait before sending the email, as YouTube does not show the updated metadata straight away
             print("Motion detected! Waiting 60 seconds before sending the email...")
             time.sleep(60)
             send_motion_email(email_config, video_id, motion, yt_config["motion_playlist_id"])
-            yt.add_to_playlist(video_id, yt_config["motion_playlist_id"])
         else:
             try:
                 send2trash.send2trash(filename)


### PR DESCRIPTION
Wait before sending the motion email, to allow YouTube to refresh and display the updated title and description.

Also add to the "motion to review" playlist before sending the email.

Resolves #98