### PR TITLE
Reuse existing livestream where one is saved and valid

### DIFF
--- a/config-template.ini
+++ b/config-template.ini
@@ -19,6 +19,10 @@ pushbullet_device = Browser
 # The ID of the playlist to add videos with motion to
 motion_playlist_id = ABC123
 
+# The URL to the livestream, in the format rtmp://x.rtmp.youtube.com/live2/abcd-efgh-1234-5678-abcd
+# Run with the --new-stream-url flag to get a new URL
+livestream_url = url_here
+
 
 [email]
 # Details to connect to the SMTP server using SSL

--- a/config-template.ini
+++ b/config-template.ini
@@ -21,7 +21,6 @@ motion_playlist_id = ABC123
 
 # The URL to the livestream, in the format rtmp://x.rtmp.youtube.com/live2/abcd-efgh-1234-5678-abcd
 # The ID of the livestream, a random string of characters
-# Run with the --new-stream-url flag to get a new URL and ID
 livestream_url = url_here
 livestream_id = id_here
 

--- a/config-template.ini
+++ b/config-template.ini
@@ -20,8 +20,10 @@ pushbullet_device = Browser
 motion_playlist_id = ABC123
 
 # The URL to the livestream, in the format rtmp://x.rtmp.youtube.com/live2/abcd-efgh-1234-5678-abcd
-# Run with the --new-stream-url flag to get a new URL
+# The ID of the livestream, a random string of characters
+# Run with the --new-stream-url flag to get a new URL and ID
 livestream_url = url_here
+livestream_id = id_here
 
 
 [email]

--- a/yt_livestream.py
+++ b/yt_livestream.py
@@ -685,6 +685,18 @@ class YouTubeLivestream(google_services.YouTube):
         LOGGER.info("Unused broadcasts cleaned up successfully!")
 
     @staticmethod
+    def validate_livestream_url(url: str) -> bool:
+        """Validate the livestream URL.
+
+        :param url: the URL to validate
+        :type url: str
+        :return: whether the URL is valid
+        :rtype: bool
+        """
+
+        return len(url) == 56 and "rtmp.youtube.com" in url and "rtmp://" in url
+
+    @staticmethod
     def parse_scheduled_time(time_str: str) -> datetime:
         """Parse a scheduled time string into a datetime object.
 
@@ -751,19 +763,18 @@ def main():
 
         # Read the options
         opt_parser = OptionParser()
-        opt_parser.add_option("--new-stream-url", action="store_true", dest="new_stream",
+        opt_parser.add_option("--new-stream-url", action="store_true", dest="new_stream_url",
                               default=False)
         options, _ = opt_parser.parse_args()
 
         # Create a new stream URL and exit if requested
-        if options.new_stream or len(str(yt_config["livestream_url"])) != 56 or str(
-                yt_config["livestream_url"]).lower()[0:25] != "rtmp://x.rtmp.youtube.com":
+        if options.new_stream_url or not yt.validate_livestream_url(
+                str(yt_config["livestream_url"])):
             url = yt.get_stream_url()
             print(f"\nThe new livestream URL is {url}    \n")
             print("Save this to the config.ini file and rerun the script.")
             return
 
-        yt = YouTubeLivestream(yt_config)
         yt.cleanup_unused_broadcasts()
 
         # Create the stream

--- a/yt_livestream.py
+++ b/yt_livestream.py
@@ -443,7 +443,7 @@ class YouTubeLivestream(google_services.YouTube):
         :rtype: yt_types.StreamStatus
         """
 
-        streams: list[yt_types.YouTubeLiveStream] = self.execute_request(
+        streams: List[yt_types.YouTubeLiveStream] = self.execute_request(
             self.get_service().liveStreams().list(
                 id=self.livestream_id, part="status"))["items"]
 
@@ -692,7 +692,7 @@ class YouTubeLivestream(google_services.YouTube):
             return False
 
         # Check the stream exists
-        streams: list[yt_types.YouTubeLiveStream] = self.execute_request(
+        streams: List[yt_types.YouTubeLiveStream] = self.execute_request(
             self.get_service().liveStreams().list(
                 id=self.livestream_id, part="id,cdn"))["items"]
         LOGGER.debug("Streams are: \n%s.", json.dumps(streams, indent=4))

--- a/yt_livestream.py
+++ b/yt_livestream.py
@@ -434,12 +434,12 @@ class YouTubeLivestream(google_services.YouTube):
         :rtype: yt_types.StreamStatus
         """
 
-        streams: yt_types.YouTubeLiveStreamList = self.execute_request(
+        streams: list[yt_types.YouTubeLiveStream] = self.execute_request(
             self.get_service().liveStreams().list(
-                id=self.livestream_id, part="status"))
+                id=self.livestream_id, part="status"))["items"]
 
-        LOGGER.debug("Stream status is: %s.", streams["items"][0]["status"])
-        return streams["items"][0]["status"]
+        LOGGER.debug("Stream status is: %s.", streams[0]["status"])
+        return streams[0]["status"]
 
     def update_video_metadata(
             self,

--- a/yt_livestream.py
+++ b/yt_livestream.py
@@ -770,8 +770,9 @@ def main():
         # Create a new stream URL and exit if requested
         if options.new_stream_url or not yt.validate_livestream_url(
                 str(yt_config["livestream_url"])):
-            url = yt.get_stream_url()
-            print(f"\nThe new livestream URL is {url}    \n")
+            stream = yt.create_livestream()
+            print(f"\nThe new livestream URL is {stream['url']}    \n")
+            print(f"\nThe new livestream ID is {stream['id']}    \n")
             print("Save this to the config.ini file and rerun the script.")
             return
 

--- a/yt_livestream.py
+++ b/yt_livestream.py
@@ -15,6 +15,7 @@ import time
 import traceback
 from datetime import datetime, timedelta
 from enum import Enum, auto
+from optparse import OptionParser
 from typing import Optional, Dict, List
 
 import googleapiclient
@@ -746,6 +747,22 @@ def main():
     email_config: configparser.SectionProxy = parser["email"]
 
     try:
+        yt = YouTubeLivestream(yt_config)
+
+        # Read the options
+        opt_parser = OptionParser()
+        opt_parser.add_option("--new-stream-url", action="store_true", dest="new_stream",
+                              default=False)
+        options, _ = opt_parser.parse_args()
+
+        # Create a new stream URL and exit if requested
+        if options.new_stream or len(str(yt_config["livestream_url"])) != 56 or str(
+                yt_config["livestream_url"]).lower()[0:25] != "rtmp://x.rtmp.youtube.com":
+            url = yt.get_stream_url()
+            print(f"\nThe new livestream URL is {url}    \n")
+            print("Save this to the config.ini file and rerun the script.")
+            return
+
         yt = YouTubeLivestream(yt_config)
         yt.cleanup_unused_broadcasts()
 


### PR DESCRIPTION
Add two config values to save a livestream which can be reused.

When the program is run, it checks for these config values and checks that they're valid. If they are, they're used. If not, new ones are generated which the user is prompted to save.

Closes #92 